### PR TITLE
fix security alerts

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,8 +71,8 @@
     "vue-style-loader": "^3.0.1",
     "vue-template-compiler": "^2.5.2",
     "webpack": "^3.6.0",
-    "webpack-bundle-analyzer": "^2.9.0",
-    "webpack-dev-server": "^2.9.1",
+    "webpack-bundle-analyzer": ">=3.3.2",
+    "webpack-dev-server": ">=3.1.11",
     "webpack-merge": "^4.1.0"
   },
   "engines": {


### PR DESCRIPTION
以下のissueの対応をしました。

webpack-bundle-analyzerが古い（3.3.2以降にアップデートする）
webpack-dev-serverが古い（3.1.11以降にアップデートする）